### PR TITLE
config modifications for security and fix python-agent log bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Sensitive files
+password.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Ansible scripts for installing php or python [New Relic](http://www.newrelic.com
   - **Status**:  Alpha
 
 ## Installation
-The project is configured to require an encrypted license.yml file -- containing the New Relic license key -- that gets opened with a password. To create the encrypted license.yml file follow [instructions](http://docs.ansible.com/ansible/playbooks_vault.html#creating-encrypted-files), entering the password above when prompted, and creating a file containing the following.
+The project is configured to require an encrypted license.yml file -- containing the New Relic license key -- that gets opened with a password. To create the encrypted license.yml file follow [these instructions](http://docs.ansible.com/ansible/playbooks_vault.html#creating-encrypted-files), entering the password above when prompted, and creating a file containing the following.
 
 ```
 new_relic_license_key: <insertyournewreliclicensekey>
 ```
-**Local Installation:** For local testing, after `vagrant up` the resulting virtual box serves a local python application at http://127.0.0.1:8080/myapp and a PHP application at http://127.0.0.1:8080/info.php. Create and store the vault password locally in password.txt. 
+**Local Installation:** For local testing, after `vagrant up` the resulting virtual box serves a local python application at http://127.0.0.1:8080/myapp and a PHP application at http://127.0.0.1:8080/info.php. Create and store the vault password locally in `password.txt`. 
     
 **Remote Installation:**
 Create an `inventory_file`:
@@ -29,7 +29,7 @@ If using Jenkins, you can securely store the ansible vault password in an enviro
 ansible-playbook provisioners/provision.yml -i inventory_file --vault-password-file=get_vault_password.py -e @license.yml
 ```
 
-where get_vault_password.py prints the environment variable:
+where `get_vault_password.py` provides the environment variable storing your ansible vault password:
 ```
 import os
 print os.environ['NEW_RELIC_VAULT_PASSWORD']

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     
 Ansible scripts for installing php or python [New Relic](http://www.newrelic.com) agents, as well as very simple LAMP php or wsgi python applications on CentOS 6.5. The agents report application statistics to New Relic and the web apps are present so to test that the Agent installation will work as expected.
 
-  - **Technology stack**: CentOS 6.5, Apache, Mod_wsgi, Python2.7, PHP, Ansible, Vagrant.
+  - **Technology stack**: CentOS 6.5, Apache, Mod_wsgi, MySQL, Python2.7, PHP, Ansible, Vagrant.
   - **Status**:  Alpha
 
 ## Installation

--- a/provisioners/provision.yml
+++ b/provisioners/provision.yml
@@ -15,6 +15,7 @@
   roles:
     - python27
     - apache
+    - mysql
     - wsgi_app
     - newrelic_wsgi
 

--- a/provisioners/roles/newrelic_php/defaults/main.yml
+++ b/provisioners/roles/newrelic_php/defaults/main.yml
@@ -4,5 +4,5 @@ newrelic_ini_path: "/etc/php.d/"
 newrelic_agent_path: "/var/log/newrelic/"
 newrelic_ini_file: "{{newrelic_ini_path}}/newrelic.ini"
 newrelic_agentlog_file: "{{newrelic_agent_path}}/php_agent.log"
-application_name: "PHP App1"
+application_name: "test LAMP php application"
 newrelic_high_security: true

--- a/provisioners/roles/newrelic_php/tasks/main.yml
+++ b/provisioners/roles/newrelic_php/tasks/main.yml
@@ -33,7 +33,7 @@
   sudo: yes
 
 - name: modify php newrelic.error_collector
-  lineinfile: dest={{newrelic_ini_file}} state=present regexp="newrelic.error_collector.record_database_errors =" line="newrelic.error_collector.record_database_errors = false"
+  lineinfile: dest={{newrelic_ini_file}} state=present regexp="newrelic.error_collector.record_database_errors =" line="newrelic.error_collector.record_database_errors = true"
   sudo: yes
 
 - name: modify php newrelic.error_collector.record_database_errors
@@ -44,8 +44,16 @@
   lineinfile: dest={{newrelic_ini_file}} state=present regexp="newrelic.daemon.auditlog =" line="newrelic.daemon.auditlog = /var/log/newrelic/audit.log"
   sudo: yes
 
+- name: modify php newrelic.error_collector.prioritize_api_errors
+  lineinfile: dest={{newrelic_ini_file}} state=present regexp="newrelic.error_collector.prioritize_api_errors =" line="newrelic.error_collector.prioritize_api_errors = true"
+  sudo: yes
+
 - name: modify php newrelic.analytics_events.capture_attributes
   lineinfile: dest={{newrelic_ini_file}} state=present regexp="newrelic.analytics_events.capture_attributes =" line="newrelic.analytics_events.capture_attributes = true"
+  sudo: yes
+
+- name: modify php newrelic.ini newrelic.capture_params
+  lineinfile: dest={{newrelic_ini_file}} state=present insertafter="[newrelic]" regexp="newrelic.capture_params =" line="newrelic.capture_params = true"
   sudo: yes
 
 - name: modify php newrelic.ini logfile

--- a/provisioners/roles/newrelic_wsgi/defaults/main.yml
+++ b/provisioners/roles/newrelic_wsgi/defaults/main.yml
@@ -4,5 +4,5 @@ newrelic_ini_path: /opt/newrelic/
 newrelic_agentlog_path: /tmp
 newrelic_ini_file: "{{newrelic_ini_path}}/newrelic.ini"
 newrelic_agentlog_file: "{{newrelic_agentlog_path}}/newrelic_python_agent.log"
-application_name: "Python App1"
+application_name: "test LAMP wsgi python application"
 newrelic_high_security: true

--- a/provisioners/roles/newrelic_wsgi/defaults/main.yml
+++ b/provisioners/roles/newrelic_wsgi/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # defaults file for newrelic_wsgi
 newrelic_ini_path: /opt/newrelic/
-newrelic_agentlog_path: /var/log/newrelic/
+newrelic_agentlog_path: /tmp
 newrelic_ini_file: "{{newrelic_ini_path}}/newrelic.ini"
-newrelic_agentlog_file: "{{newrelic_agentlog_path}}/python_agent.log"
+newrelic_agentlog_file: "{{newrelic_agentlog_path}}/newrelic_python_agent.log"
 application_name: "Python App1"
 newrelic_high_security: true

--- a/provisioners/roles/newrelic_wsgi/tasks/main.yml
+++ b/provisioners/roles/newrelic_wsgi/tasks/main.yml
@@ -29,7 +29,7 @@
   sudo: yes
 
 - name: modify python newrelic.ini logfile
-  lineinfile: dest={{newrelic_ini_file}} state=present regexp="log_file =" line="newrelic.logfile = {{newrelic_agentlog_file}}"
+  lineinfile: dest={{newrelic_ini_file}} state=present regexp="log_file =" line="log_file = {{newrelic_agentlog_file}}"
   sudo: yes
 
 - name: add agent config to the wsgi file
@@ -41,10 +41,3 @@
   sudo: yes
   notify:
     - restart apache
-  
-#    /usr/local/bin/newrelic-admin validate-config  /opt/newrelic/newrelic.ini
-
-
-
-    
-    


### PR DESCRIPTION
Add settings to match a security baseline, and moved the python agent log into /tmp/ (Apache doesn't have permission to write logs to /var/log/newrelic/ ).
