### PR TITLE
Revert "specify a path to find PIP"

### DIFF
--- a/provisioners/roles/newrelic_wsgi/tasks/main.yml
+++ b/provisioners/roles/newrelic_wsgi/tasks/main.yml
@@ -13,8 +13,6 @@
 - name: pip install newrelic
   pip: name=newrelic
        extra_args='--install-option="--install-scripts=/usr/bin"'
-  environment:
-    PATH: /usr/local/bin:/bin:/usr/bin
   sudo: yes
 
 - name: use newrelic-admin to generate ini


### PR DESCRIPTION
We're going to specify environment information at the provisioner level,
not the task level.

This reverts commit e3bc2b74f8051a2b7f9b5b99cce84c643051c4b9.
