### PR TITLE
Add optional environment, fix log settings,   

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.verbose = 'v'
     ansible.vault_password_file = 'password.txt'
     ansible.extra_vars = "@license.yml"
+    ansible.raw_arguments ='--extra-vars={"env_file":"../env_vars.yml"}'
     ansible.groups = {
         "php-app" => ["default"],
         "python-app" => ["default"],

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.verbose = 'v'
     ansible.vault_password_file = 'password.txt'
     ansible.extra_vars = "@license.yml"
-    ansible.raw_arguments ='--extra-vars={"env_file":"../env_vars.yml"}'
+    ansible.raw_arguments ='--extra-vars={"env_file":"../default_environment.yml"}'
     ansible.groups = {
         "php-app" => ["default"],
         "python-app" => ["default"],

--- a/default_environment.yml
+++ b/default_environment.yml
@@ -1,8 +1,8 @@
 ---
-# example source for environment variables
+# default source for environment variables
     
 env_vars:
-    EG_VAR: /a-var/
+    DEFAULT_NEWRELIC_ENVIRONMENT_VARIABLE:   
 #    PATH: /usr/local/
 #    http_proxy: http://
 #    https_proxy: https://

--- a/env_vars.yml
+++ b/env_vars.yml
@@ -1,0 +1,8 @@
+---
+# example source for environment variables
+    
+env_vars:
+    EG_VAR: /a-var/
+#    PATH: /usr/local/
+#    http_proxy: http://
+#    https_proxy: https://

--- a/provisioners/provision.yml
+++ b/provisioners/provision.yml
@@ -9,6 +9,9 @@
     - mysql
     - php
     - newrelic_php
+  vars_files:
+    - "{{ env_file }}"
+  environment: env_vars
 
 - hosts: python-app
   gather_facts: False
@@ -18,13 +21,22 @@
     - mysql
     - wsgi_app
     - newrelic_wsgi
+  vars_files:
+    - "{{ env_file }}"
+  environment: "{{env_vars}}"
 
 - hosts: nr-php
   gather_facts: False
   roles:
     - newrelic_php
+  vars_files:
+    - "{{ env_file }}"
+  environment: "{{env_vars}}"
 
 - hosts: nr-python
   gather_facts: False
   roles:
     - newrelic_wsgi
+  vars_files:
+    - "{{ env_file }}"
+  environment: "{{env_vars}}"

--- a/provisioners/provision.yml
+++ b/provisioners/provision.yml
@@ -23,7 +23,7 @@
     - newrelic_wsgi
   vars_files:
     - "{{ env_file }}"
-  environment: "{{env_vars}}"
+  environment: env_vars
 
 - hosts: nr-php
   gather_facts: False
@@ -31,7 +31,7 @@
     - newrelic_php
   vars_files:
     - "{{ env_file }}"
-  environment: "{{env_vars}}"
+  environment: env_vars
 
 - hosts: nr-python
   gather_facts: False
@@ -39,4 +39,4 @@
     - newrelic_wsgi
   vars_files:
     - "{{ env_file }}"
-  environment: "{{env_vars}}"
+  environment: env_vars

--- a/provisioners/roles/newrelic_php/defaults/main.yml
+++ b/provisioners/roles/newrelic_php/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # defaults file for newrelic_php
+daemon_proxy: ""
 newrelic_ini_path: "/etc/php.d/"
 newrelic_ini_file: "{{newrelic_ini_path}}/newrelic.ini"
 newrelic_agentlog_path: "/var/log/newrelic/"

--- a/provisioners/roles/newrelic_php/tasks/main.yml
+++ b/provisioners/roles/newrelic_php/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 # tasks file for newrelic_php
 
+- name: record variables supplied by environment file
+  shell: echo "{{ env_vars }}"
+  sudo: yes
+
 - name: install rpm
   yum: name=rpm
   sudo: yes
@@ -34,7 +38,7 @@
   sudo: yes
 
 - name: modify php newrelic.error_collector
-  lineinfile: dest={{newrelic_ini_file}} state=present regexp="newrelic.error_collector.record_database_errors =" line="newrelic.error_collector.record_database_errors = true"
+  lineinfile: dest={{newrelic_ini_file}} state=present regexp="newrelic.error_collector.enabled =" line="newrelic.error_collector.enabled = true"
   sudo: yes
 
 - name: modify php newrelic.error_collector.record_database_errors
@@ -59,6 +63,10 @@
 
 - name: modify php newrelic.ini newrelic.capture_params
   lineinfile: dest={{newrelic_ini_file}} state=present insertafter="[newrelic]" regexp="newrelic.capture_params =" line="newrelic.capture_params = true"
+  sudo: yes
+
+- name: modify php newrelic.ini newrelic.daemon.proxy
+  lineinfile: dest={{newrelic_ini_file}} state=present insertafter="[newrelic]" regexp="newrelic.daemon.proxy =" line="newrelic.daemon.proxy = {{daemon_proxy}}"
   sudo: yes
 
 - name: modify php newrelic.ini logfile

--- a/provisioners/roles/newrelic_wsgi/tasks/main.yml
+++ b/provisioners/roles/newrelic_wsgi/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 # tasks file for newrelic_wsgi
 
+- name: record variables supplied by environment file 
+  shell: echo "{{ env_vars }}"
+  sudo: yes
 
 #    https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/python-agent-admin-script
 - name: create directory for newrelic config


### PR DESCRIPTION
Fix log settings (#8): this fixes a bug, but doesn't change behavior (@marcesher, see my issue comment).  

Supply environment (#5) with `default_environment.yml` as the default. Note that `env_vars` must be a dictionary, which seems to necessitate that a dummy value be supplied by the yaml file. 

Add an optional daemon proxy (#6).
