### PR TITLE
Updates to work with Ansible 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ansible scripts for installing php or python [New Relic](http://www.newrelic.com
 The project is configured to require an encrypted license.yml file -- containing the New Relic license key -- that gets opened with a password. To create the encrypted license.yml file follow [these instructions](http://docs.ansible.com/ansible/playbooks_vault.html#creating-encrypted-files), entering the password above when prompted, and creating a file containing the following.
 
 ```
-new_relic_license_key: <insertyournewreliclicensekey>
+newrelic_license_key: <insertyournewreliclicensekey>
 ```
 **Local Installation:** For local testing, after `vagrant up` the resulting virtual box serves a local python application at http://127.0.0.1:8080/myapp and a PHP application at http://127.0.0.1:8080/info.php. Create and store the vault password locally in `password.txt`. 
     

--- a/provisioners/provision.yml
+++ b/provisioners/provision.yml
@@ -11,7 +11,7 @@
     - newrelic_php
   vars_files:
     - "{{ env_file }}"
-  environment: env_vars
+  environment: "{{ env_vars }}"
 
 - hosts: python-app
   gather_facts: False
@@ -23,7 +23,7 @@
     - newrelic_wsgi
   vars_files:
     - "{{ env_file }}"
-  environment: env_vars
+  environment: "{{ env_vars }}"
 
 - hosts: nr-php
   gather_facts: False
@@ -31,7 +31,7 @@
     - newrelic_php
   vars_files:
     - "{{ env_file }}"
-  environment: env_vars
+  environment: "{{ env_vars }}"
 
 - hosts: nr-python
   gather_facts: False
@@ -39,4 +39,4 @@
     - newrelic_wsgi
   vars_files:
     - "{{ env_file }}"
-  environment: env_vars
+  environment: "{{ env_vars }}"


### PR DESCRIPTION
1. Fixes Ansible playbook to be compatible with version 2.0+, as the bare variable `env_vars` is no longer accepted (see [the porting guide](https://github.com/ansible/ansible/blob/devel/docsite/rst/porting_guide_2.0.rst)).
   
   Without changing these to e.g. `"{{ env_vars }}"` you get warnings/errors like:
   
   ``` sh
   [DEPRECATION WARNING]: Using bare variables for environment is deprecated. 
   Update your playbooks so that the environment value uses the full variable 
   syntax ('{{foo}}'). This feature will be removed in a future release. 
   Deprecation warnings can be disabled by setting deprecation_warnings=False in 
   ansible.cfg.
   fatal: [default]: FAILED! => {"failed": true, "msg": "ERROR! environment must be a dictionary, received env_vars (<class 'ansible.parsing.yaml.objects.AnsibleUnicode'>)"}
   ```
2. Fixes typo in the `README.md` which doesn't correctly include the license key variable name.
