### PR TITLE
Brief psuedo code for example using template for newrelic.ini

### DIFF
--- a/provisioners/roles/newrelic_wsgi/defaults/main.yml
+++ b/provisioners/roles/newrelic_wsgi/defaults/main.yml
@@ -6,3 +6,4 @@ newrelic_ini_file: "{{newrelic_ini_path}}/newrelic.ini"
 newrelic_agentlog_file: "{{newrelic_agentlog_path}}/newrelic-python-agent.log"
 application_name: "test LAMP wsgi python application"
 newrelic_high_security: true
+whitelist_exceptions: "KeyError TypeError" # search how to configure this here: https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/python-agent-configuration

--- a/provisioners/roles/newrelic_wsgi/tasks/main.yml
+++ b/provisioners/roles/newrelic_wsgi/tasks/main.yml
@@ -27,26 +27,16 @@
        extra_args='--install-option="--install-scripts=/usr/bin"'
   sudo: yes
 
-- name: use newrelic-admin to generate ini
-  command: newrelic-admin generate-config {{newrelic_license_key}} {{newrelic_ini_file}}
+- name: genetate newrelic.ini file
   sudo: yes
-
-# lineinfile only replaces the last matching lines; use replace for multiple app_name replaces
-- name: modify python newrelic.ini app name
-  replace: dest={{newrelic_ini_file}} regexp='.*app_name =.*\n' replace="app_name = {{application_name}}\n"
-  sudo: yes
-
-- name: modify python newrelic.ini high security on
-  lineinfile: dest={{newrelic_ini_file}} state=present regexp="high_security =" line="high_security = true"
-  sudo: yes
-
-- name: modify python newrelic.ini logfile
-  lineinfile: dest={{newrelic_ini_file}} state=present regexp="log_file =" line="log_file = {{newrelic_agentlog_file}}"
-  sudo: yes
-
-- name: modify python newrelic.ini whitelist
-  lineinfile: dest={{newrelic_ini_file}} insertafter="license_key =" state=present regexp="strip_exception_messages\.whitelist =" line="strip_exception_messages.whitelist = KeyError TypeError"
-  sudo: yes
+  template:
+    src: /templates/newrelic.ini.j2
+    dest: {{ newrelic_ini_file }}
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart apache    
 
 - name: make empty log file with right permissions 
   file:
@@ -60,12 +50,12 @@
 - name: add agent config to the wsgi file
   lineinfile: dest={{wsgi_scriptfile}} state=present line="newrelic.agent.initialize('{{newrelic_ini_file}}')" insertbefore=BOF
   sudo: yes
+  notify:
+    - restart apache    
 
 - name: import newrelic to wsgi
   lineinfile: dest={{wsgi_scriptfile}} state=present line="import newrelic.agent" insertbefore=BOF
   sudo: yes
+  notify:
+    - restart apache    
 
-- name: restart apache server
-  service: name=httpd state=restarted sleep=1
-  sudo: yes
-  ignore_errors: yes

--- a/provisioners/roles/newrelic_wsgi/templates/newrelic.ini.j2
+++ b/provisioners/roles/newrelic_wsgi/templates/newrelic.ini.j2
@@ -1,0 +1,207 @@
+# ---------------------------------------------------------------------------
+
+#
+# This file configures the New Relic Python Agent.
+#
+# The path to the configuration file should be supplied to the function
+# newrelic.agent.initialize() when the agent is being initialized.
+#
+# The configuration file follows a structure similar to what you would
+# find for Microsoft Windows INI files. For further information on the
+# configuration file format see the Python ConfigParser documentation at:
+#
+#    http://docs.python.org/library/configparser.html
+#
+# For further discussion on the behaviour of the Python agent that can
+# be configured via this configuration file see:
+#
+#    http://newrelic.com/docs/python/python-agent-configuration
+#
+
+# ---------------------------------------------------------------------------
+
+# Here are the settings that are common to all environments.
+
+[newrelic]
+
+# You must specify the license key associated with your New
+# Relic account. This key binds the Python Agent's data to your
+# account in the New Relic service.
+license_key = {{newrelic_license_key}}
+strip_exception_messages.whitelist = {{ whitelist_exceptions }}
+
+# The application name. Set this to be the name of your
+# application as you would like it to show up in New Relic UI.
+# The UI will then auto-map instances of your application into a
+# entry on your home dashboard page.
+app_name = {{ application_name }}
+
+# When "true", the agent collects performance data about your
+# application and reports this data to the New Relic UI at
+# newrelic.com. This global switch is normally overridden for
+# each environment below.
+monitor_mode = true
+
+# Sets the name of a file to log agent messages to. Useful for
+# debugging any issues with the agent. This is not set by
+# default as it is not known in advance what user your web
+# application processes will run as and where they have
+# permission to write to. Whatever you set this to you must
+# ensure that the permissions for the containing directory and
+# the file itself are correct, and that the user that your web
+# application runs as can write to the file. If not able to
+# write out a log file, it is also possible to say "stderr" and
+# output to standard error output. This would normally result in
+# output appearing in your web server log.
+log_file = {{ newrelic_agentlog_file }}
+
+# Sets the level of detail of messages sent to the log file, if
+# a log file location has been provided. Possible values, in
+# increasing order of detail, are: "critical", "error", "warning",
+# "info" and "debug". When reporting any agent issues to New
+# Relic technical support, the most useful setting for the
+# support engineers is "debug". However, this can generate a lot
+# of information very quickly, so it is best not to keep the
+# agent at this level for longer than it takes to reproduce the
+# problem you are experiencing.
+log_level = info
+
+# The Python Agent communicates with the New Relic service using
+# SSL by default. Note that this does result in an increase in
+# CPU overhead, over and above what would occur for a non SSL
+# connection, to perform the encryption involved in the SSL
+# communication. This work is though done in a distinct thread
+# to those handling your web requests, so it should not impact
+# response times. You can if you wish revert to using a non SSL
+# connection, but this will result in information being sent
+# over a plain socket connection and will not be as secure.
+ssl = true
+
+# High Security Mode enforces certain security settings, and
+# prevents them from being overridden, so that no sensitive data
+# is sent to New Relic. Enabling High Security Mode means that
+# SSL is turned on, request parameters are not collected, and SQL
+# can not be sent to New Relic in its raw form. To activate High
+# Security Mode, it must be set to 'true' in this local .ini
+# configuration file AND be set to 'true' in the server-side
+# configuration in the New Relic user interface. For details, see
+# https://docs.newrelic.com/docs/subscriptions/high-security
+high_security = {{ newrelic_high_security }}
+
+# The Python Agent will attempt to connect directly to the New
+# Relic service. If there is an intermediate firewall between
+# your host and the New Relic service that requires you to use a
+# HTTP proxy, then you should set both the "proxy_host" and
+# "proxy_port" settings to the required values for the HTTP
+# proxy. The "proxy_user" and "proxy_pass" settings should
+# additionally be set if proxy authentication is implemented by
+# the HTTP proxy. The "proxy_scheme" setting dictates what
+# protocol scheme is used in talking to the HTTP proxy. This
+# would normally always be set as "http" which will result in the
+# agent then using a SSL tunnel through the HTTP proxy for end to
+# end encryption.
+# proxy_scheme = http
+# proxy_host = hostname
+# proxy_port = 8080
+# proxy_user =
+# proxy_pass =
+
+# Capturing request parameters is off by default. To enable the
+# capturing of request parameters, first ensure that the setting
+# "attributes.enabled" is set to "true" (the default value), and
+# then add "request.parameters.*" to the "attributes.include"
+# setting. For details about attributes configuration, please
+# consult the documentation.
+# attributes.include = request.parameters.*
+
+# The transaction tracer captures deep information about slow
+# transactions and sends this to the UI on a periodic basis. The
+# transaction tracer is enabled by default. Set this to "false"
+# to turn it off.
+transaction_tracer.enabled = true
+
+# Threshold in seconds for when to collect a transaction trace.
+# When the response time of a controller action exceeds this
+# threshold, a transaction trace will be recorded and sent to
+# the UI. Valid values are any positive float value, or (default)
+# "apdex_f", which will use the threshold for a dissatisfying
+# Apdex controller action - four times the Apdex T value.
+transaction_tracer.transaction_threshold = apdex_f
+
+# When the transaction tracer is on, SQL statements can
+# optionally be recorded. The recorder has three modes, "off"
+# which sends no SQL, "raw" which sends the SQL statement in its
+# original form, and "obfuscated", which strips out numeric and
+# string literals.
+transaction_tracer.record_sql = obfuscated
+
+# Threshold in seconds for when to collect stack trace for a SQL
+# call. In other words, when SQL statements exceed this
+# threshold, then capture and send to the UI the current stack
+# trace. This is helpful for pinpointing where long SQL calls
+# originate from in an application.
+transaction_tracer.stack_trace_threshold = 0.5
+
+# Determines whether the agent will capture query plans for slow
+# SQL queries. Only supported in MySQL and PostgreSQL. Set this
+# to "false" to turn it off.
+transaction_tracer.explain_enabled = true
+
+# Threshold for query execution time below which query plans
+# will not not be captured. Relevant only when "explain_enabled"
+# is true.
+transaction_tracer.explain_threshold = 0.5
+
+# Space separated list of function or method names in form
+# 'module:function' or 'module:class.function' for which
+# additional function timing instrumentation will be added.
+transaction_tracer.function_trace =
+
+# The error collector captures information about uncaught
+# exceptions or logged exceptions and sends them to UI for
+# viewing. The error collector is enabled by default. Set this
+# to "false" to turn it off.
+error_collector.enabled = true
+
+# To stop specific errors from reporting to the UI, set this to
+# a space separated list of the Python exception type names to
+# ignore. The exception name should be of the form 'module:class'.
+error_collector.ignore_errors =
+
+# Browser monitoring is the Real User Monitoring feature of the UI.
+# For those Python web frameworks that are supported, this
+# setting enables the auto-insertion of the browser monitoring
+# JavaScript fragments.
+browser_monitoring.auto_instrument = true
+
+# A thread profiling session can be scheduled via the UI when
+# this option is enabled. The thread profiler will periodically
+# capture a snapshot of the call stack for each active thread in
+# the application to construct a statistically representative
+# call tree.
+thread_profiler.enabled = true
+
+# ---------------------------------------------------------------------------
+
+#
+# The application environments. These are specific settings which
+# override the common environment settings. The settings related to a
+# specific environment will be used when the environment argument to the
+# newrelic.agent.initialize() function has been defined to be either
+# "development", "test", "staging" or "production".
+#
+
+[newrelic:development]
+monitor_mode = false
+
+[newrelic:test]
+monitor_mode = false
+
+[newrelic:staging]
+app_name = rram dev python
+monitor_mode = true
+
+[newrelic:production]
+monitor_mode = true
+
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
@sleitner @marcesher @vickumar1981 @m3brown 

We can decided whether to fix up, test, and execute using a template to create the newrelic.ini but here is what it would look like.
1. The high security mode is not currently being used.
2. Our latest changes now restart apache no matter what.
3. These changes would only force a restart if wsgi_scriptfile, or the ini file changed. 
4. If the values for whitelist_exception are blank the line should be missing not = empty string. (line 31 in newrelic.ini.j2) 
