### PR TITLE
Add no-op settings for auditing; improve exception whitelist

### DIFF
--- a/provisioners/roles/newrelic_wsgi/tasks/main.yml
+++ b/provisioners/roles/newrelic_wsgi/tasks/main.yml
@@ -48,6 +48,12 @@
   lineinfile: dest={{newrelic_ini_file}} insertafter="license_key =" state=present regexp="strip_exception_messages\.whitelist =" line="strip_exception_messages.whitelist = KeyError TypeError"
   sudo: yes
 
+# These configs are added to satisfy security auditing requirements, even though they're set to the same as the default.
+
+- name: modify python newrelic.ini developer_mode
+  lineinfile: dest={{newrelic_ini_file}} insertafter="license_key =" state=present line="developer_mode = false"
+  sudo: yes
+
 - name: make empty log file with right permissions 
   file:
     dest={{newrelic_agentlog_file}}

--- a/provisioners/roles/newrelic_wsgi/tasks/main.yml
+++ b/provisioners/roles/newrelic_wsgi/tasks/main.yml
@@ -45,7 +45,7 @@
   sudo: yes
 
 - name: modify python newrelic.ini whitelist
-  lineinfile: dest={{newrelic_ini_file}} insertafter="license_key =" state=present regexp="strip_exception_messages\.whitelist =" line="strip_exception_messages.whitelist = KeyError TypeError"
+  lineinfile: dest={{newrelic_ini_file}} insertafter="license_key =" state=present regexp="strip_exception_messages\.whitelist =" line="strip_exception_messages.whitelist = Exception AttributeError IndexError ImportError KeyError TypeError django.db.utils:IntegrityError django.core.exceptions:FieldError django.core.exceptions:ValidationError jinja2.exceptions:UndefinedError jinja2.exceptions:TemplateNotFound urllib2:URLError"
   sudo: yes
 
 # These additional newrelic.ini configs are added to satisfy security auditing requirements, even though they're set to the same as the default. These are no-op, since they're set to the defaults.

--- a/provisioners/roles/newrelic_wsgi/tasks/main.yml
+++ b/provisioners/roles/newrelic_wsgi/tasks/main.yml
@@ -48,10 +48,13 @@
   lineinfile: dest={{newrelic_ini_file}} insertafter="license_key =" state=present regexp="strip_exception_messages\.whitelist =" line="strip_exception_messages.whitelist = KeyError TypeError"
   sudo: yes
 
-# These configs are added to satisfy security auditing requirements, even though they're set to the same as the default.
-
+# These additional newrelic.ini configs are added to satisfy security auditing requirements, even though they're set to the same as the default. These are no-op, since they're set to the defaults.
 - name: modify python newrelic.ini developer_mode
   lineinfile: dest={{newrelic_ini_file}} insertafter="license_key =" state=present line="developer_mode = false"
+  sudo: yes
+
+- name: modify python newrelic.ini xray_session
+  lineinfile: dest={{newrelic_ini_file}} insertafter="license_key =" state=present line="xray_session.enabled = true"
   sudo: yes
 
 - name: make empty log file with right permissions 


### PR DESCRIPTION
This adds several settings to be explicitly set to their defaults, for auditing requirements.

In addition, it adds additional exceptions to the exception whitelist
