### PR TITLE
Add exceptions to the strip exceptions whitelist

### DIFF
--- a/provisioners/roles/newrelic_wsgi/tasks/main.yml
+++ b/provisioners/roles/newrelic_wsgi/tasks/main.yml
@@ -45,7 +45,7 @@
   sudo: yes
 
 - name: modify python newrelic.ini whitelist
-  lineinfile: dest={{newrelic_ini_file}} insertafter="license_key =" state=present regexp="strip_exception_messages\.whitelist =" line="strip_exception_messages.whitelist = Exception AttributeError IndexError ImportError KeyError TypeError django.db.utils:IntegrityError django.core.exceptions:FieldError django.core.exceptions:ValidationError jinja2.exceptions:UndefinedError jinja2.exceptions:TemplateNotFound urllib2:URLError"
+  lineinfile: dest={{newrelic_ini_file}} insertafter="license_key =" state=present regexp="strip_exception_messages\.whitelist =" line="strip_exception_messages.whitelist = Exception AttributeError IndexError ImportError KeyError TypeError ValueError django.db.utils:IntegrityError django.db.utils:OperationalError django.db.utils:ProgrammingError django.core.exceptions:FieldError django.core.exceptions:ValidationError django.template.base:TemplateSyntaxError jinja2.exceptions:UndefinedError jinja2.exceptions:TemplateNotFound knowledgebase.models:MultipleObjectsReturned requests.exceptions:HTTPError urllib2:URLError"
   sudo: yes
 
 # These additional newrelic.ini configs are added to satisfy security auditing requirements, even though they're set to the same as the default. These are no-op, since they're set to the defaults.


### PR DESCRIPTION
This PR adds the following exceptions that we're seeing in cf.gov prod python to our strip exception message whitelist:
- django.db.utils:OperationalError 
- django.db.utils:ProgrammingError
- django.template.base:TemplateSyntaxError
- knowledgebase.models:MultipleObjectsReturned
- requests.exceptions:HTTPError
