### PR TITLE
Remove 404 from ignored HTTP status codes

### DIFF
--- a/provisioners/roles/newrelic_wsgi/tasks/main.yml
+++ b/provisioners/roles/newrelic_wsgi/tasks/main.yml
@@ -47,6 +47,11 @@
 - name: modify python newrelic.ini whitelist
   lineinfile: dest={{newrelic_ini_file}} insertafter="license_key =" state=present regexp="strip_exception_messages\.whitelist =" line="strip_exception_messages.whitelist = Exception AttributeError IndexError ImportError KeyError TypeError ValueError django.db.utils:IntegrityError django.db.utils:OperationalError django.db.utils:ProgrammingError django.core.exceptions:FieldError django.core.exceptions:ValidationError django.template.base:TemplateSyntaxError jinja2.exceptions:UndefinedError jinja2.exceptions:TemplateNotFound knowledgebase.models:MultipleObjectsReturned requests.exceptions:HTTPError urllib2:URLError"
   sudo: yes
+  
+# 404 errors are ignored by default. We want to track them so 404 has been removed from this list.
+- name: modify python newrelic.ini ignored status codes
+  lineinfile: dest={{newrelic_ini_file}} insertafter="license_key =" state=present regexp="error_collector\.ignore_status_codes =" line="error_collector.ignore_status_codes = 300 301 302 303 304 305 306 307 308 200 201 202 203 204 205 206 207 208 226 100 101 102"
+  sudo: yes
 
 # These additional newrelic.ini configs are added to satisfy security auditing requirements, even though they're set to the same as the default. These are no-op, since they're set to the defaults.
 - name: modify python newrelic.ini developer_mode


### PR DESCRIPTION
NR ignores 404 errors by default. We'd like to start tracking them. See https://discuss.newrelic.com/t/how-to-track-404-requests/1406
